### PR TITLE
Fix(tests): Silence console.error in tests expecting errors

### DIFF
--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -294,9 +294,11 @@ describe('ApiClient', () => {
       const errorMessage = 'Network Error';
       mockAxiosInstance.get.mockRejectedValue(new Error(errorMessage));
 
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       await expect(client.getGroup(groupSlug)).rejects.toThrow(errorMessage);
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/groups/${groupSlug}`);
+      consoleErrorSpy.mockRestore();
     });
 
     it('should use the default baseURL if none is provided', () => {
@@ -364,9 +366,11 @@ describe('ApiClient', () => {
       const errorMessage = 'API Error';
       mockAxiosInstance.get.mockRejectedValue(new Error(errorMessage));
 
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       await expect(client.getAlbumInGroup(groupSlug, albumUuid)).rejects.toThrow(errorMessage);
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/groups/${groupSlug}/albums/${albumUuid}`);
+      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -452,9 +456,11 @@ describe('ApiClient', () => {
       const errorMessage = 'API Error';
       mockAxiosInstance.get.mockRejectedValue(new Error(errorMessage));
 
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       await expect(client.getProject(projectIdentifier)).rejects.toThrow(errorMessage);
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/projects/${projectIdentifier}`);
+      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -500,9 +506,11 @@ describe('ApiClient', () => {
       const errorMessage = 'API Error';
       mockAxiosInstance.get.mockRejectedValue(new Error(errorMessage));
 
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       await expect(client.getAlbumStats()).rejects.toThrow(errorMessage);
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/albums/stats');
+      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -547,9 +555,11 @@ describe('ApiClient', () => {
       const errorMessage = 'API Error';
       mockAxiosInstance.get.mockRejectedValue(new Error(errorMessage));
 
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       await expect(client.getUserAlbumStats()).rejects.toThrow(errorMessage);
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/user-albums/stats');
+      consoleErrorSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
I modified specific tests in `tests/client.test.ts` that are designed to assert error throwing behavior. In these tests, the `ApiClient` methods call `console.error` before re-throwing an error. This is expected behavior for the client but produces noisy test logs.

Changes:
- For the five tests that check error handling for API call failures (in `getGroup`, `getAlbumInGroup`, `getProject`, `getAlbumStats`, `getUserAlbumStats`), `console.error` is now spied on using `jest.spyOn` and its implementation is temporarily replaced with a no-op function.
- The original `console.error` implementation is restored at the end of each of these tests.

This ensures that the tests still correctly assert that errors are thrown, but the expected `console.error` calls from the client during these specific test scenarios do not appear in the test output, leading to a cleaner CI log. Other unexpected console errors will still be visible.