### PR TITLE
feat: Configure project for NPM publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to NPM
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18' # Or your desired Node.js version
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Publish to NPM
+        run: npm publish --access public # Add --access public if it's a public package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # 1001-albums-js-api
 A typescript typed JS api client for 1001 albums
+
+## Installation
+
+You can install the package using npm:
+
+```bash
+npm install app
+```
+
+## Usage
+
+Here's a basic example of how to use the library:
+
+```typescript
+// Import the client
+import { ApiClient } from 'app'; // Or whatever the main export is
+
+// Initialize the client (if necessary)
+// const client = new ApiClient(); // This depends on the library's design
+
+// Example usage (replace with actual library functionality)
+// async function fetchData() {
+//   try {
+//     const data = await client.someMethod();
+//     console.log(data);
+//   } catch (error) {
+//     console.error('Error fetching data:', error);
+//   }
+// }
+
+// fetchData();
+```

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "app",
   "version": "1.0.0",
+  "private": false,
   "description": "A typescript typed JS api client for 1001 albums",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "lint": "eslint ."
   },
   "repository": {
@@ -19,6 +22,11 @@
     "url": "https://github.com/bnm12/1001-albums-js-api/issues"
   },
   "homepage": "https://github.com/bnm12/1001-albums-js-api#readme",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^8.32.1",


### PR DESCRIPTION
This commit introduces the necessary configurations and workflows to publish the package to NPM.

Changes include:
- Updated `package.json` to include publishing-related fields such as `main`, `types`, `files`, and `prepublishOnly` script. Set `private` to `false`.
- Ensured `tsconfig.json` is set up to generate type definitions in the `dist` folder. (No changes were needed as it was already configured).
- Ensured a `build` script (`tsc`) exists in `package.json`. (No changes were needed as it was already present).
- Added a new GitHub Actions workflow (`.github/workflows/publish.yml`) to automate publishing to NPM when new version tags (e.g., v1.0.0) are pushed. The workflow builds the project and uses an NPM_TOKEN secret for authentication.
- Updated `README.md` to include sections for "Installation" (using `npm install app`) and a placeholder "Usage" example.