### PR TITLE
Update NPM publish workflow to align with best practices.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,26 @@
 name: Publish to NPM
 
 on:
-  push:
-    tags:
-      - 'v*.*.*' # Trigger on version tags like v1.0.0
+  release:
+    types: [published]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18' # Or your desired Node.js version
+          node-version: '20.x' # Or your desired Node.js version
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci
       - name: Build
         run: npm run build
       - name: Publish to NPM
-        run: npm publish --access public # Add --access public if it's a public package
+        run: npm publish --provenance --access public # Add --access public if it's a public package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This change updates the GitHub Actions workflow for publishing to NPM:
- Switched trigger from tags to release `published` type.
- Updated Node.js to version '20.x'.
- Updated actions/checkout and actions/setup-node to v4.
- Added `permissions` for `id-token: write` to enable publish provenance.
- Added `--provenance` flag to `npm publish` command for enhanced security.
- Maintained `--access public` for public package publishing.
- Ensured `NODE_AUTH_TOKEN` is used for authentication.