### PR TITLE
feat: Add index.html for client demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Albums Generator Client Demo</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+        .container { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        input[type="text"] { padding: 10px; margin-right: 10px; border: 1px solid #ddd; border-radius: 4px; width: calc(100% - 120px); }
+        button { padding: 10px 15px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; }
+        button:hover { background-color: #0056b3; }
+        pre { background-color: #eee; padding: 15px; border-radius: 4px; white-space: pre-wrap; word-wrap: break-word; }
+        .error { color: red; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Albums Generator Client Demo</h1>
+        <p>
+            Enter a project identifier (e.g., "1001-albums-you-must-hear-before-you-die")
+            and click "Fetch Project Data" to see the JSON response.
+        </p>
+        <div>
+            <input type="text" id="projectIdentifier" placeholder="Enter project identifier">
+            <button id="fetchButton">Fetch Project Data</button>
+        </div>
+        <h2>API Response:</h2>
+        <pre id="responseArea"></pre>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/albums-generator-client@latest/dist/client.umd.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const client = new AlbumsGeneratorClient();
+
+            const fetchButton = document.getElementById('fetchButton');
+            const projectIdentifierInput = document.getElementById('projectIdentifier');
+            const responseArea = document.getElementById('responseArea');
+
+            fetchButton.addEventListener('click', async () => {
+                const projectId = projectIdentifierInput.value.trim();
+                if (!projectId) {
+                    responseArea.textContent = 'Please enter a project identifier.';
+                    responseArea.classList.add('error');
+                    return;
+                }
+
+                responseArea.textContent = 'Loading...';
+                responseArea.classList.remove('error');
+
+                try {
+                    const data = await client.getProject(projectId);
+                    responseArea.textContent = JSON.stringify(data, null, 2);
+                } catch (error) {
+                    console.error('Error fetching project data:', error);
+                    responseArea.textContent = `Error: ${error.message || 'Failed to fetch data. See console for details.'}`;
+                    responseArea.classList.add('error');
+                }
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds a simple index.html page to demonstrate the albums-generator-client.

The page allows you to:
- Input a project identifier.
- Click a button to fetch project data using the UMD version of the client from a CDN (@latest).
- View the JSON response displayed in a text area.

This provides a basic technical demonstration of the client's functionality and is intended for use with GitHub Pages.