### PR TITLE
Fix: Correct UMD export for AlbumsGeneratorClient

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <pre id="responseArea"></pre>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/albums-generator-client@latest/dist/client.umd.js"></script>
+    <script src="./dist/client.umd.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const fetchButton = document.getElementById('fetchButton');
@@ -48,7 +48,8 @@
                 responseArea.classList.remove('error');
 
                 try {
-                    const data = await AlbumsGeneratorClient.getProject(projectId);
+                    const client = new AlbumsGeneratorClient();
+                    const data = await client.getProject(projectId);
                     responseArea.textContent = JSON.stringify(data, null, 2);
                 } catch (error) {
                     console.error('Error fetching project data:', error);

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,6 +10,7 @@ export default {
     format: 'umd',
     name: 'AlbumsGeneratorClient', // This will be the global variable name
     sourcemap: true,
+    exports: 'default',
     globals: {
       // If you have external dependencies that you don't want to bundle,
       // you would list them here. For axios, we want it bundled.

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import { Group, AlbumInGroup, Project, AlbumStats, UserAlbumStats } from './type
 
 const DEFAULT_BASE_URL = 'https://1001albumsgenerator.com/api/v1';
 
-export class AlbumsGeneratorClient {
+export default class AlbumsGeneratorClient {
   private axiosInstance: AxiosInstance;
   private requestTimestamps: number[] = [];
   private readonly RATE_LIMIT_COUNT = 3;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { AlbumsGeneratorClient } from './client';
+export { default } from './client';
 export * from './types';

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AlbumsGeneratorClient } from '../src/client';
+import AlbumsGeneratorClient from '../src/client';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;


### PR DESCRIPTION
The UMD bundle was previously exporting an object that contained AlbumsGeneratorClient as a property. This required you to instantiate the client using `new AlbumsGeneratorClient.AlbumsGeneratorClient()`.

This commit changes the export structure so that the UMD global `AlbumsGeneratorClient` is the class constructor itself. This allows instantiation via `new AlbumsGeneratorClient()`.

Changes include:
- Made `AlbumsGeneratorClient` in `src/client.ts` a default export.
- Updated `src/index.ts` to export the default from `client.ts`.
- Configured Rollup (`rollup.config.mjs`) with `exports: 'default'` for the UMD output.
- Updated `index.html` to demonstrate the correct instantiation and to use the local build for testing.
- Adjusted `tests/client.test.ts` to correctly import the default `AlbumsGeneratorClient`.