### PR TITLE
feat: Implement 11-second request interval for rate limiting

### DIFF
--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -765,7 +765,7 @@ describe('AlbumsGeneratorClient', () => {
       // Call 1
       await client.getAlbumStats(); // Effective T = 0
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
-      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), expect. يزيد عن(0)); // Check not called with any value > 0
+      expect(setTimeoutSpy).not.toHaveBeenCalled(); // Corrected: First call should not have positive delay
 
       // Advance time by 5 seconds
       jest.advanceTimersByTime(5 * 1000); // Current time T = 5s
@@ -789,7 +789,7 @@ describe('AlbumsGeneratorClient', () => {
       // Call 1
       await client.getAlbumStats(); // Effective T = 0
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
-      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), expect. يزيد عن(0));
+      expect(setTimeoutSpy).not.toHaveBeenCalled(); // Corrected: First call should not have positive delay
 
       // Advance time by 12 seconds (more than MIN_REQUEST_INTERVAL_MS)
       jest.advanceTimersByTime(12 * 1000); // Current time T = 12s


### PR DESCRIPTION
This change updates the client-side rate limiting mechanism to include a new rule: a minimum interval of 11 seconds between any two requests. This is in addition to the existing limit of 3 requests per minute.

The `AlbumsGeneratorClient` in `src/client.ts` has been modified:
- A new constant `MIN_REQUEST_INTERVAL_MS` (11000ms) was added.
- The `handleRateLimit` method now calculates potential wait times based on both the 3-requests-per-minute rule and the 11-second-interval rule.
- The client will wait for the longer of these two calculated durations, ensuring both rate limits are respected.

The unit tests in `tests/client.test.ts` have been significantly updated:
- New tests were added to specifically verify the 11-second interval logic, including scenarios where it is the stricter rule.
- Existing rate limiting tests were refactored to account for the combined effect of both rules. Assertions now check the precise `setTimeout` values to confirm that the correct wait time is applied based on whichever rule is more restrictive in a given scenario.
- Fake timers are used throughout to simulate time progression and validate the behavior under various request patterns.